### PR TITLE
feat: support Codex CLI 0.149.1 and proxy subpaths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN npm install -g @openai/codex@${CODEX_CLI_VERSION}
 COPY --from=frontend-builder /app/public ./public/
 RUN pnpm build
 
-# ── Stage 3: Runtime ─────────────────────────────────────────────────
-FROM debian:trixie-slim AS runtime
+# ── Stage 3: Shared runtime system ───────────────────────────────────
+FROM debian:trixie-slim AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
@@ -71,6 +71,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN command -v 7za >/dev/null
 
+# ── Stage 4: Root toolchain seed ─────────────────────────────────────
+# Build the user toolchain outside the final image. The final image receives
+# only the compressed seed, avoiding a second copy of the same /root tree in
+# its immutable layers.
+FROM runtime-base AS toolchain-builder
+
 # Install mise + runtimes
 RUN curl -fsSL https://mise.run | sh
 
@@ -96,23 +102,13 @@ RUN npm install -g \
 # Enable corepack for pnpm (needed for native addon rebuild)
 RUN npm install -g pnpm@10.18.3
 
-# Create app directories
-RUN mkdir -p /root/.codex /workspaces /app/logs
+# Caches are installation by-products, not part of the user toolchain.
+RUN mkdir -p /root/.codex /opt \
+ && rm -rf /root/.cache /root/.npm \
+ && tar -C /root -czf /opt/root-seed.tar.gz .
 
-# Workaround: codex on Linux app-server mode doesn't inject arg0 tools into
-# child process PATH. Create stable symlinks so apply_patch etc. are always
-# available. All arg0 tools are the codex multi-call binary (argv[0] dispatch).
-RUN CODEX_BIN="$(find /root/.local/share/mise -name codex -path '*/vendor/*/codex/codex' -type f 2>/dev/null | head -1)" \
- && if [ -n "$CODEX_BIN" ]; then \
-      for tool in apply_patch applypatch codex-execve-wrapper codex-linux-sandbox; do \
-        ln -sf "$CODEX_BIN" "/usr/local/bin/$tool"; \
-      done; \
-      echo "Linked codex arg0 tools -> $CODEX_BIN"; \
-    else \
-      echo "WARNING: codex vendor binary not found, arg0 tools not linked"; \
-    fi
-
-# ── App installation ─────────────────────────────────────────────────
+# ── Stage 5: Production Node dependencies ────────────────────────────
+FROM toolchain-builder AS app-deps-builder
 WORKDIR /app
 
 # Install production dependencies and rebuild native addons
@@ -121,14 +117,24 @@ RUN pnpm install --frozen-lockfile --prod
 RUN npx --yes node-gyp rebuild --directory=node_modules/node-pty || true \
   && npx --yes node-gyp rebuild --directory=node_modules/better-sqlite3 || true
 
+# ── Stage 6: Runtime ─────────────────────────────────────────────────
+FROM runtime-base AS runtime
+
+ARG CODEX_CLI_VERSION=0.149.1
+ENV CODEX_CLI_VERSION=${CODEX_CLI_VERSION}
+
+WORKDIR /app
+
+# The toolchain exists only once in the final image and is restored into a
+# mounted /root on first start.
+COPY --from=toolchain-builder /opt/root-seed.tar.gz /opt/root-seed.tar.gz
+COPY --from=app-deps-builder /app/node_modules ./node_modules/
+COPY package.json pnpm-lock.yaml* ./
+
 # Copy built assets and migrations
 COPY --from=backend-builder /app/dist ./dist/
 COPY --from=backend-builder /app/public ./public/
 COPY drizzle/ ./drizzle/
-
-# ── Seed root tarball ────────────────────────────────────────────────
-# Captures mise, node, codex, mcp-tools, bashrc, configs
-RUN tar -C /root -czf /opt/root-seed.tar.gz .
 
 # ── Entrypoint ───────────────────────────────────────────────────────
 RUN cat > /usr/local/bin/entrypoint.sh <<'ENTRYPOINT_EOF'
@@ -138,6 +144,22 @@ set -euo pipefail
 ROOT_SEED="/opt/root-seed.tar.gz"
 ROOT_MARKER="/root/.codex-webui-initialized"
 VERSION_MARKER="/root/.codex-webui-version"
+
+rebuild_codex_arg0_symlinks() {
+  # Codex on Linux app-server mode does not inject its argv[0] tools into
+  # child-process PATH. All of these names dispatch through the same binary.
+  local codex_bin
+  codex_bin="$(find /root/.local/share/mise -type f -name codex \
+    \( -path '*/vendor/*/bin/codex' -o -path '*/vendor/*/codex/codex' \) \
+    2>/dev/null | head -1)"
+  if [ -n "${codex_bin}" ]; then
+    for tool in apply_patch applypatch codex-execve-wrapper codex-linux-sandbox; do
+      ln -sf "${codex_bin}" "/usr/local/bin/${tool}"
+    done
+  else
+    echo "[entrypoint] WARNING: Codex vendor binary not found; arg0 tools were not linked"
+  fi
+}
 
 is_root_empty() {
   find /root -mindepth 1 -maxdepth 1 -print -quit | grep -q . && return 1
@@ -173,18 +195,13 @@ if [ -n "${EXPECTED_VER}" ] && [ "${EXPECTED_VER}" != "${INSTALLED_VER}" ]; then
     echo "${EXPECTED_VER}" > "${VERSION_MARKER}"
     echo "[entrypoint] Codex upgraded to ${EXPECTED_VER}"
 
-    # Rebuild arg0 symlinks (codex multi-call binary may have moved)
-    CODEX_BIN="$(find /root/.local/share/mise -name codex -path '*/vendor/*/codex/codex' -type f 2>/dev/null | head -1)"
-    if [ -n "${CODEX_BIN}" ]; then
-      for tool in apply_patch applypatch codex-execve-wrapper codex-linux-sandbox; do
-        ln -sf "${CODEX_BIN}" "/usr/local/bin/${tool}"
-      done
-      echo "[entrypoint] Rebuilt arg0 symlinks -> ${CODEX_BIN}"
-    fi
   else
     echo "[entrypoint] WARNING: Codex upgrade failed, continuing with installed version"
   fi
 fi
+
+# Build or refresh stable Codex argv[0] links after seed restore and upgrades.
+rebuild_codex_arg0_symlinks
 
 # Ensure directories exist (in case volume is pre-populated but partial)
 mkdir -p /root/.codex /workspaces /app/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app/web
 COPY web/package.json web/pnpm-lock.yaml* web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/ ./
+ARG WEBUI_BASE_PATH=/
+ENV WEBUI_BASE_PATH=${WEBUI_BASE_PATH}
 RUN pnpm build
 
 # ── Stage 2: Backend build ───────────────────────────────────────────
@@ -19,7 +21,7 @@ RUN pnpm install --frozen-lockfile
 COPY src/ ./src/
 COPY tsconfig*.json nest-cli.json ./
 # Generate codex schema types (needs codex CLI)
-ARG CODEX_CLI_VERSION=0.149.0
+ARG CODEX_CLI_VERSION=0.149.1
 RUN npm install -g @openai/codex@${CODEX_CLI_VERSION}
 COPY --from=frontend-builder /app/public ./public/
 RUN pnpm build
@@ -84,7 +86,7 @@ RUN node --version \
  && mise --version
 
 # Install global npm tools (codex + MCP utilities)
-ARG CODEX_CLI_VERSION=0.149.0
+ARG CODEX_CLI_VERSION=0.149.1
 ENV CODEX_CLI_VERSION=${CODEX_CLI_VERSION}
 RUN npm install -g \
     @openai/codex@${CODEX_CLI_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pnpm install --frozen-lockfile
 COPY src/ ./src/
 COPY tsconfig*.json nest-cli.json ./
 # Generate codex schema types (needs codex CLI)
-ARG CODEX_CLI_VERSION=0.123.0
+ARG CODEX_CLI_VERSION=0.149.0
 RUN npm install -g @openai/codex@${CODEX_CLI_VERSION}
 COPY --from=frontend-builder /app/public ./public/
 RUN pnpm build
@@ -84,7 +84,7 @@ RUN node --version \
  && mise --version
 
 # Install global npm tools (codex + MCP utilities)
-ARG CODEX_CLI_VERSION=0.123.0
+ARG CODEX_CLI_VERSION=0.149.0
 ENV CODEX_CLI_VERSION=${CODEX_CLI_VERSION}
 RUN npm install -g \
     @openai/codex@${CODEX_CLI_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /app/web
 COPY web/package.json web/pnpm-lock.yaml* web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/ ./
-ARG WEBUI_BASE_PATH=/
-ENV WEBUI_BASE_PATH=${WEBUI_BASE_PATH}
 RUN pnpm build
 
 # ── Stage 2: Backend build ───────────────────────────────────────────

--- a/README.en.md
+++ b/README.en.md
@@ -230,6 +230,41 @@ server {
 
 When using Docker Compose, change `proxy_pass` to `http://codex-webui:8172` and replace `ports` with `expose`.
 
+### Deploying under a subpath
+
+When the public URL is not at the domain root (for example, `https://cc.example.com/codex/`), build the frontend with the same base path. This configures static assets, frontend routing, REST APIs, and Socket.IO together:
+
+```bash
+docker build \
+  --build-arg WEBUI_BASE_PATH=/codex/ \
+  --build-arg CODEX_CLI_VERSION=0.149.1 \
+  -t codex-webui:0.149.1-codex .
+```
+
+Nginx must retain `/codex/` in browser-facing URLs and strip it when proxying to the backend. The trailing slashes on both `location` and `proxy_pass` are required:
+
+```nginx
+location = /codex {
+    return 301 /codex/;
+}
+
+location /codex/ {
+    proxy_pass http://127.0.0.1:8172/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade    $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Prefix /codex;
+    proxy_read_timeout 300s;
+}
+```
+
+`WEBUI_BASE_PATH` is a Docker **build argument**, not a runtime environment variable. Rebuild the image after changing it. For OnlyOffice, set `general.publicBaseUrl` to the full URL including the subpath, for example `https://cc.example.com/codex`.
+
 ### Caddy
 
 Caddy auto-provisions Let's Encrypt certificates and handles WebSocket upgrades automatically:

--- a/README.en.md
+++ b/README.en.md
@@ -232,13 +232,12 @@ When using Docker Compose, change `proxy_pass` to `http://codex-webui:8172` and 
 
 ### Deploying under a subpath
 
-When the public URL is not at the domain root (for example, `https://cc.example.com/codex/`), build the frontend with the same base path. This configures static assets, frontend routing, REST APIs, and Socket.IO together:
+The same image can serve both a domain root and a proxy subpath (for example, `https://cc.example.com/codex/`) without rebuilding for each path. A subpath proxy must use `X-Forwarded-Prefix` to tell the WebUI its browser-facing public path:
 
 ```bash
 docker build \
-  --build-arg WEBUI_BASE_PATH=/codex/ \
   --build-arg CODEX_CLI_VERSION=0.149.1 \
-  -t codex-webui:0.149.1-codex .
+  -t codex-webui:0.149.1 .
 ```
 
 Nginx must retain `/codex/` in browser-facing URLs and strip it when proxying to the backend. The trailing slashes on both `location` and `proxy_pass` are required:
@@ -263,7 +262,7 @@ location /codex/ {
 }
 ```
 
-`WEBUI_BASE_PATH` is a Docker **build argument**, not a runtime environment variable. Rebuild the image after changing it. For OnlyOffice, set `general.publicBaseUrl` to the full URL including the subpath, for example `https://cc.example.com/codex`.
+A root proxy does not need `X-Forwarded-Prefix`. The WebUI dynamically generates the correct base for static assets, frontend routes, REST APIs, and Socket.IO on every request, so one image can serve both proxy styles. For OnlyOffice, set `general.publicBaseUrl` to the full URL including the subpath, for example `https://cc.example.com/codex`.
 
 ### Caddy
 

--- a/README.md
+++ b/README.md
@@ -232,13 +232,12 @@ Docker Compose 中使用时，`proxy_pass` 改为 `http://codex-webui:8172`，�
 
 ### 部署到子目录
 
-若公开地址不是域名根目录（例如 `https://cc.example.com/codex/`），前端必须在构建时使用相同的基础路径。该参数会同时配置静态资源、前端路由、REST API 和 Socket.IO 路径：
+同一个镜像可以同时用于域名根目录和代理子目录（例如 `https://cc.example.com/codex/`），无需为每个路径重新构建。子目录代理需要通过 `X-Forwarded-Prefix` 告诉 WebUI 浏览器侧的公开路径：
 
 ```bash
 docker build \
-  --build-arg WEBUI_BASE_PATH=/codex/ \
   --build-arg CODEX_CLI_VERSION=0.149.1 \
-  -t codex-webui:0.149.1-codex .
+  -t codex-webui:0.149.1 .
 ```
 
 Nginx 必须保留浏览器侧的 `/codex/` 前缀，并在转发到后端时将它移除。`location` 和 `proxy_pass` 末尾的 `/` 均不可省略：
@@ -263,7 +262,7 @@ location /codex/ {
 }
 ```
 
-`WEBUI_BASE_PATH` 是 Docker **构建参数**，不是运行时环境变量。修改路径后需要重新构建镜像。若使用 OnlyOffice，请将 `general.publicBaseUrl` 设置为包含子目录的完整地址，例如 `https://cc.example.com/codex`。
+根目录反代无需设置 `X-Forwarded-Prefix`。WebUI 会按每个请求动态生成正确的静态资源、前端路由、REST API 和 Socket.IO 基础路径，因此同一镜像可同时服务两种代理方式。若使用 OnlyOffice，请将 `general.publicBaseUrl` 设置为包含子目录的完整地址，例如 `https://cc.example.com/codex`。
 
 ### Caddy
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,41 @@ server {
 
 Docker Compose 中使用时，`proxy_pass` 改为 `http://codex-webui:8172`，并将 `ports` 改为 `expose`。
 
+### 部署到子目录
+
+若公开地址不是域名根目录（例如 `https://cc.example.com/codex/`），前端必须在构建时使用相同的基础路径。该参数会同时配置静态资源、前端路由、REST API 和 Socket.IO 路径：
+
+```bash
+docker build \
+  --build-arg WEBUI_BASE_PATH=/codex/ \
+  --build-arg CODEX_CLI_VERSION=0.149.1 \
+  -t codex-webui:0.149.1-codex .
+```
+
+Nginx 必须保留浏览器侧的 `/codex/` 前缀，并在转发到后端时将它移除。`location` 和 `proxy_pass` 末尾的 `/` 均不可省略：
+
+```nginx
+location = /codex {
+    return 301 /codex/;
+}
+
+location /codex/ {
+    proxy_pass http://127.0.0.1:8172/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade    $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Prefix /codex;
+    proxy_read_timeout 300s;
+}
+```
+
+`WEBUI_BASE_PATH` 是 Docker **构建参数**，不是运行时环境变量。修改路径后需要重新构建镜像。若使用 OnlyOffice，请将 `general.publicBaseUrl` 设置为包含子目录的完整地址，例如 `https://cc.example.com/codex`。
+
 ### Caddy
 
 Caddy 自动签发 Let's Encrypt 证书，自动处理 WebSocket 升级：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     # build:
     #   context: .
     #   args:
-    #     CODEX_CLI_VERSION: "0.149.0"
+    #     CODEX_CLI_VERSION: "0.149.1"
+    #     WEBUI_BASE_PATH: "/codex/"  # Set when proxying under a subpath
     ports:
       - "${PORT:-8172}:8172"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     #   context: .
     #   args:
     #     CODEX_CLI_VERSION: "0.149.1"
-    #     WEBUI_BASE_PATH: "/codex/"  # Set when proxying under a subpath
     ports:
       - "${PORT:-8172}:8172"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # build:
     #   context: .
     #   args:
-    #     CODEX_CLI_VERSION: "0.123.0"
+    #     CODEX_CLI_VERSION: "0.149.0"
     ports:
       - "${PORT:-8172}:8172"
     environment:

--- a/src/codex/codex-process-manager.service.ts
+++ b/src/codex/codex-process-manager.service.ts
@@ -163,7 +163,10 @@ export class CodexProcessManager implements OnModuleInit, OnModuleDestroy {
           title: 'Codex WebUI',
           version: '0.1.0',
         },
-        capabilities: { experimentalApi: true },
+        capabilities: {
+          experimentalApi: true,
+          requestAttestation: false,
+        },
       });
       this.generation += 1;
       this.logger.log(

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,15 @@ import {
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from 'nestjs-pino';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/all-exceptions.filter';
+import {
+  normalizeForwardedPrefix,
+  renderIndexHtml,
+} from './public-base-path';
 import { FILES_SETTING_KEYS } from './settings/settings.definitions';
 import { SettingsService } from './settings/settings.service';
 
@@ -43,6 +50,31 @@ async function bootstrap() {
   app.useGlobalFilters(new AllExceptionsFilter());
   app.useWebSocketAdapter(new IoAdapter(app));
   app.setGlobalPrefix('api', { exclude: ['/'] });
+
+  const indexHtml = await readFile(
+    join(__dirname, '..', 'public', 'index.html'),
+    'utf8',
+  );
+  app.getHttpAdapter().getInstance().addHook(
+    'onSend',
+    async (request, reply, payload) => {
+      const contentType = String(reply.getHeader('content-type') ?? '');
+      if (
+        request.method !== 'GET' ||
+        request.url.startsWith('/api') ||
+        !contentType.startsWith('text/html')
+      ) {
+        return payload;
+      }
+
+      if (payload instanceof Readable) payload.destroy();
+      reply.removeHeader('content-length');
+      const basePath = normalizeForwardedPrefix(
+        request.headers['x-forwarded-prefix'],
+      );
+      return renderIndexHtml(indexHtml, basePath);
+    },
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     const swaggerConfig = new DocumentBuilder()

--- a/src/plugins/dto/plugins.dto.ts
+++ b/src/plugins/dto/plugins.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { jsonValueSchema } from '../../codex/dto/v2/openapi.schema';
 
 export const PLUGIN_INSTALL_POLICY_VALUES = [
@@ -207,9 +207,6 @@ export class PluginInstallRequestDto {
 
   @ApiProperty()
   pluginName!: string;
-
-  @ApiPropertyOptional()
-  forceRemoteSync?: boolean;
 }
 
 /** Response for plugin/install. */
@@ -225,9 +222,6 @@ export class PluginInstallResponseDto {
 export class PluginUninstallRequestDto {
   @ApiProperty()
   pluginId!: string;
-
-  @ApiPropertyOptional()
-  forceRemoteSync?: boolean;
 }
 
 /** Empty response body for plugin/uninstall. */

--- a/src/plugins/plugins.controller.ts
+++ b/src/plugins/plugins.controller.ts
@@ -36,18 +36,12 @@ export class PluginsController {
   @Get()
   @ApiOperation({ summary: 'List Codex plugin marketplaces' })
   @ApiQuery({ name: 'cwds', required: false, isArray: true })
-  @ApiQuery({ name: 'forceRemoteSync', required: false, type: Boolean })
   @ApiOkResponse({ type: PluginListResponseDto })
   listPlugins(
     @Query('cwds') cwds?: string | string[],
-    @Query('forceRemoteSync') forceRemoteSync?: string,
   ): Promise<v2.PluginListResponse> {
     return this.pluginsService.listPlugins({
       cwds: this.parseStringList(cwds),
-      forceRemoteSync: this.parseOptionalBoolean(
-        forceRemoteSync,
-        'forceRemoteSync',
-      ),
     });
   }
 
@@ -90,10 +84,6 @@ export class PluginsController {
         'marketplacePath',
       ),
       pluginName: this.requireTrimmedString(body.pluginName, 'pluginName'),
-      forceRemoteSync: this.parseOptionalBoolean(
-        body.forceRemoteSync,
-        'forceRemoteSync',
-      ),
     });
   }
 
@@ -113,10 +103,6 @@ export class PluginsController {
     }
     return this.pluginsService.uninstallPlugin({
       pluginId: this.requireTrimmedString(body.pluginId, 'pluginId'),
-      forceRemoteSync: this.parseOptionalBoolean(
-        body.forceRemoteSync,
-        'forceRemoteSync',
-      ),
     });
   }
 
@@ -129,21 +115,6 @@ export class PluginsController {
       );
     }
     return value.trim();
-  }
-
-  private parseOptionalBoolean(
-    value: boolean | string | undefined,
-    field: string,
-  ): boolean | undefined {
-    if (value === undefined) return undefined;
-    if (typeof value === 'boolean') return value;
-    if (value === 'true') return true;
-    if (value === 'false') return false;
-    throw BusinessException.badRequest(
-      ErrorCode.validation.typeMismatch,
-      `${field} must be a boolean`,
-      { field, type: 'boolean' },
-    );
   }
 
   private parseStringList(value?: string | string[]): string[] | undefined {

--- a/src/public-base-path.spec.ts
+++ b/src/public-base-path.spec.ts
@@ -1,0 +1,31 @@
+import {
+  normalizeForwardedPrefix,
+  PUBLIC_BASE_PATH_TOKEN,
+  renderIndexHtml,
+} from './public-base-path';
+
+describe('public base path', () => {
+  it.each([
+    [undefined, '/'],
+    ['', '/'],
+    ['/', '/'],
+    ['/codex', '/codex/'],
+    ['/codex/', '/codex/'],
+    ['//tools///codex//', '/tools/codex/'],
+  ])('normalizes %p to %p', (input, expected) => {
+    expect(normalizeForwardedPrefix(input)).toBe(expected);
+  });
+
+  it.each(['codex', '/codex?<script>', '/codex#fragment', '/codex\\path']) (
+    'rejects unsafe value %p',
+    (input) => {
+      expect(normalizeForwardedPrefix(input)).toBe('/');
+    },
+  );
+
+  it('replaces the runtime marker', () => {
+    expect(
+      renderIndexHtml(`<base href="${PUBLIC_BASE_PATH_TOKEN}">`, '/codex/'),
+    ).toBe('<base href="/codex/">');
+  });
+});

--- a/src/public-base-path.ts
+++ b/src/public-base-path.ts
@@ -1,0 +1,23 @@
+/** Marker kept in the built index and replaced for each HTML response. */
+export const PUBLIC_BASE_PATH_TOKEN = '__CODEX_WEBUI_BASE_PATH__';
+
+/**
+ * Normalizes a trusted reverse-proxy prefix for use in an HTML base href.
+ * Invalid values fall back to the domain root instead of entering the page.
+ */
+export function normalizeForwardedPrefix(
+  header: string | string[] | undefined,
+): string {
+  const raw = Array.isArray(header) ? header[0] : header;
+  const candidate = raw?.split(',', 1)[0]?.trim();
+  if (!candidate || candidate === '/') return '/';
+  if (!candidate.startsWith('/') || /["'<>?#\\]/.test(candidate)) return '/';
+
+  const segments = candidate.split('/').filter(Boolean);
+  return segments.length ? `/${segments.join('/')}/` : '/';
+}
+
+/** Renders the built SPA index for the current public proxy prefix. */
+export function renderIndexHtml(indexHtml: string, basePath: string): string {
+  return indexHtml.replaceAll(PUBLIC_BASE_PATH_TOKEN, basePath);
+}

--- a/src/threads/thread-resume-registry.service.ts
+++ b/src/threads/thread-resume-registry.service.ts
@@ -49,7 +49,6 @@ export class ThreadResumeRegistryService {
     const promise = this.codex
       .request<v2.ThreadResumeResponse>('thread/resume', {
         threadId,
-        persistExtendedHistory: true,
       })
       .then((response) => {
         if (this.epoch.get(key) === callEpoch) {

--- a/src/threads/threads.controller.ts
+++ b/src/threads/threads.controller.ts
@@ -87,8 +87,6 @@ export class ThreadsController {
       cwd: body.cwd,
       approvalPolicy:
         body.approvalPolicy as v2.ThreadStartParams['approvalPolicy'],
-      experimentalRawEvents: false,
-      persistExtendedHistory: true,
     });
   }
 

--- a/src/threads/threads.service.spec.ts
+++ b/src/threads/threads.service.spec.ts
@@ -31,16 +31,10 @@ describe('ThreadsService', () => {
     const response = { thread: { id: 't1' }, model: 'gpt-4' };
     mockCodex.request.mockResolvedValue(response);
 
-    const result = await service.startThread({
-      experimentalRawEvents: false,
-      persistExtendedHistory: true,
-    });
+    const result = await service.startThread({});
 
     expect(result).toEqual(response);
-    expect(mockCodex.request).toHaveBeenCalledWith('thread/start', {
-      experimentalRawEvents: false,
-      persistExtendedHistory: true,
-    });
+    expect(mockCodex.request).toHaveBeenCalledWith('thread/start', {});
     expect(mockResumeRegistry.markResumed).toHaveBeenCalledWith('t1');
   });
 

--- a/src/threads/threads.service.ts
+++ b/src/threads/threads.service.ts
@@ -179,7 +179,6 @@ export class ThreadsService {
       'thread/fork',
       {
         threadId,
-        persistExtendedHistory: true,
       },
     );
     this.resumeRegistry.markResumed(response.thread.id);

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <base href="__CODEX_WEBUI_BASE_PATH__" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>web</title>

--- a/web/src/api-client.ts
+++ b/web/src/api-client.ts
@@ -3,6 +3,7 @@ import { client } from './generated/api/client.gen';
 import { getApiToken, clearApiToken } from './auth-token';
 import { showSnackbar } from './stores/snackbar-store';
 import { getApiErrorMessage } from './lib/api-error';
+import { BASE_PATH } from './base-path';
 
 /** HMR-safe guard — bound to the client instance, survives module reload. */
 const clientAny = client as Record<string, unknown>;
@@ -11,6 +12,8 @@ const clientAny = client as Record<string, unknown>;
 export function configureApiClient() {
   if (clientAny.__codexWebuiConfigured) return;
   clientAny.__codexWebuiConfigured = true;
+
+  client.setConfig({ baseUrl: BASE_PATH });
 
   client.interceptors.request.use((request) => {
     if (request.url.includes('/api/auth/login')) return request;

--- a/web/src/auth-token.ts
+++ b/web/src/auth-token.ts
@@ -1,4 +1,5 @@
 /** Manages the WebUI JWT for REST and WebSocket authentication. */
+import { withBasePath } from './base-path';
 
 const STORAGE_KEY = 'codex.webui.jwt';
 
@@ -31,5 +32,5 @@ export function buildFileServeUrl(filePath: string): string {
   const token = getApiToken();
   const params = new URLSearchParams({ path: filePath });
   if (token) params.set('access_token', token);
-  return `/api/files/serve?${params.toString()}`;
+  return `${withBasePath('/api/files/serve')}?${params.toString()}`;
 }

--- a/web/src/base-path.ts
+++ b/web/src/base-path.ts
@@ -1,0 +1,8 @@
+/** Public path baked into the frontend by Vite. */
+export const BASE_PATH = import.meta.env.BASE_URL.replace(/\/+$/, '');
+
+/** Prefixes an application URL with the configured public base path. */
+export function withBasePath(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${BASE_PATH}${normalizedPath}`;
+}

--- a/web/src/base-path.ts
+++ b/web/src/base-path.ts
@@ -1,5 +1,10 @@
-/** Public path baked into the frontend by Vite. */
-export const BASE_PATH = import.meta.env.BASE_URL.replace(/\/+$/, '');
+/** Public path injected into the document by the backend at request time. */
+const documentBasePath = new URL(
+  document.querySelector('base')?.getAttribute('href') ?? '/',
+  window.location.origin,
+).pathname;
+
+export const BASE_PATH = documentBasePath.replace(/\/+$/, '');
 
 /** Prefixes an application URL with the configured public base path. */
 export function withBasePath(path: string): string {

--- a/web/src/components/files/viewers/preview-source.ts
+++ b/web/src/components/files/viewers/preview-source.ts
@@ -1,5 +1,6 @@
 /** Source abstraction shared by workspace files and read-only archive entries. */
 import { getApiToken, getAuthorizationHeader, buildFileServeUrl } from '@/auth-token';
+import { withBasePath } from '@/base-path';
 
 export type PreviewSource =
   | { kind: 'file'; filePath: string }
@@ -38,7 +39,7 @@ export function buildPreviewUrl(source: PreviewSource): string {
   const token = getApiToken();
   const params = new URLSearchParams({ path: source.archivePath, entry: source.entryPath });
   if (token) params.set('access_token', token);
-  return `/api/files/archive/entry?${params.toString()}`;
+  return `${withBasePath('/api/files/archive/entry')}?${params.toString()}`;
 }
 
 /** Builds fetch headers for preview API calls that can send Authorization. */

--- a/web/src/components/integrations/plugins-tab.tsx
+++ b/web/src/components/integrations/plugins-tab.tsx
@@ -104,7 +104,6 @@ export function PluginsTab() {
   const refreshMutation = useMutation({
     mutationFn: async () => {
       const { data } = await pluginsListPlugins({
-        query: { forceRemoteSync: true },
         throwOnError: true,
       });
       return data;

--- a/web/src/generated/api/types.gen.ts
+++ b/web/src/generated/api/types.gen.ts
@@ -1244,7 +1244,6 @@ export type PluginReadResponseDto = {
 export type PluginInstallRequestDto = {
     marketplacePath: string;
     pluginName: string;
-    forceRemoteSync?: boolean;
 };
 
 export type PluginInstallResponseDto = {
@@ -1254,7 +1253,6 @@ export type PluginInstallResponseDto = {
 
 export type PluginUninstallRequestDto = {
     pluginId: string;
-    forceRemoteSync?: boolean;
 };
 
 export type PluginUninstallResponseDto = {
@@ -2588,7 +2586,6 @@ export type PluginsListPluginsData = {
     body?: never;
     path?: never;
     query?: {
-        forceRemoteSync?: boolean;
         cwds?: Array<unknown>;
     };
     url: '/api/plugins';

--- a/web/src/hooks/use-chat-attachments.ts
+++ b/web/src/hooks/use-chat-attachments.ts
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { clearApiToken, getAuthorizationHeader } from '@/auth-token';
+import { withBasePath } from '@/base-path';
 import { escapeMentionPath } from '@/lib/mention-utils';
 import type { ChatAttachment, ChatFileAttachment, ChatImageAttachment } from '@/types/attachments';
 
@@ -150,7 +151,7 @@ export function useChatAttachments({
     const formData = new FormData();
     formData.append('file', file, file.name || 'pasted-file');
     const authorization = getAuthorizationHeader();
-    const resp = await fetch('/api/chat/upload', {
+    const resp = await fetch(withBasePath('/api/chat/upload'), {
       method: 'POST',
       headers: authorization ? { Authorization: authorization } : {},
       body: formData,

--- a/web/src/hooks/use-file-operations.ts
+++ b/web/src/hooks/use-file-operations.ts
@@ -5,6 +5,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getApiErrorMessage } from '@/lib/api-error';
+import { withBasePath } from '@/base-path';
 import {
   filesCreateFileMutation,
   filesCreateDirectoryMutation,
@@ -159,7 +160,7 @@ export function useFileOperations() {
   const uploadFiles = useMutation<UploadFilesResponse, Error, UploadFilesVariables>({
     mutationFn: async ({ destinationPath, formData }) => {
       const resp = await fetch(
-        `/api/files/upload?destinationPath=${encodeURIComponent(destinationPath)}`,
+        `${withBasePath('/api/files/upload')}?destinationPath=${encodeURIComponent(destinationPath)}`,
         {
           method: 'POST',
           headers: authHeaders(),
@@ -191,7 +192,7 @@ export function useFileOperations() {
   const downloadFile = async (filePath: string) => {
     try {
       const resp = await fetch(
-        `/api/files/download?path=${encodeURIComponent(filePath)}`,
+        `${withBasePath('/api/files/download')}?path=${encodeURIComponent(filePath)}`,
         { headers: authHeaders() },
       );
       if (!resp.ok) {

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -19,6 +19,7 @@ import { TerminalRoute } from './terminal-route';
 import { DiagnosticsRoute } from './diagnostics-route';
 import { SettingsPage } from '@/components/settings/settings-page';
 import { IntegrationsPage } from '@/components/integrations/integrations-page';
+import { BASE_PATH } from '@/base-path';
 
 export type LoginSearch = { redirect: string };
 export type IntegrationsSearch = { tab: 'plugins' | 'apps' | 'mcps' };
@@ -140,7 +141,10 @@ const routeTree = rootRoute.addChildren([
   ]),
 ]);
 
-export const router = createRouter({ routeTree });
+export const router = createRouter({
+  routeTree,
+  basepath: BASE_PATH || '/',
+});
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/web/src/socket.ts
+++ b/web/src/socket.ts
@@ -3,12 +3,14 @@
  */
 import { io, Socket } from 'socket.io-client';
 import { getApiToken } from './auth-token';
+import { withBasePath } from './base-path';
 
 let socket: Socket | null = null;
 
 export function getSocket(): Socket {
   if (!socket) {
     socket = io('/ws', {
+      path: withBasePath('/socket.io'),
       transports: ['websocket'],
       autoConnect: true,
       auth: (callback) => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,18 +3,23 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
-function normalizeBasePath(value: string | undefined): string {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed === '/') return '/';
-  return `/${trimmed.replace(/^\/+|\/+$/g, '')}/`;
-}
-
-const publicBasePath = normalizeBasePath(process.env.WEBUI_BASE_PATH);
-const proxyPrefix = publicBasePath === '/' ? '' : publicBasePath.slice(0, -1);
+const runtimeBasePathToken = '__CODEX_WEBUI_BASE_PATH__';
 
 export default defineConfig({
-  base: publicBasePath,
-  plugins: [react(), tailwindcss()],
+  // Relative build assets let one image run at / or behind any proxy prefix.
+  // The backend supplies the matching <base href> for each HTML request.
+  base: './',
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: 'runtime-base-path-dev',
+      apply: 'serve',
+      transformIndexHtml(html) {
+        return html.replaceAll(runtimeBasePathToken, '/');
+      },
+    },
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -32,14 +37,10 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      [`${proxyPrefix}/api`]: {
-        target: 'http://localhost:8172',
-        rewrite: (requestPath) => requestPath.slice(proxyPrefix.length),
-      },
-      [`${proxyPrefix}/socket.io`]: {
+      '/api': 'http://localhost:8172',
+      '/socket.io': {
         target: 'http://localhost:8172',
         ws: true,
-        rewrite: (requestPath) => requestPath.slice(proxyPrefix.length),
       },
     },
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,7 +3,17 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
+function normalizeBasePath(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === '/') return '/';
+  return `/${trimmed.replace(/^\/+|\/+$/g, '')}/`;
+}
+
+const publicBasePath = normalizeBasePath(process.env.WEBUI_BASE_PATH);
+const proxyPrefix = publicBasePath === '/' ? '' : publicBasePath.slice(0, -1);
+
 export default defineConfig({
+  base: publicBasePath,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -22,10 +32,14 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:8172',
-      '/socket.io': {
+      [`${proxyPrefix}/api`]: {
+        target: 'http://localhost:8172',
+        rewrite: (requestPath) => requestPath.slice(proxyPrefix.length),
+      },
+      [`${proxyPrefix}/socket.io`]: {
         target: 'http://localhost:8172',
         ws: true,
+        rewrite: (requestPath) => requestPath.slice(proxyPrefix.length),
       },
     },
   },


### PR DESCRIPTION
## Summary

- update the bundled Codex CLI compatibility layer and default image version to 0.149.1
- send the required `requestAttestation` initialize capability and remove request fields no longer accepted by the current app-server protocol
- support both domain-root and reverse-proxy subpath deployments with the same image
- derive frontend assets, routes, REST API, file URLs, and Socket.IO paths from a runtime `X-Forwarded-Prefix`
- reduce the final Docker image from about 3.82 GB to 1.71 GB while preserving the original runtime toolchain
- rebuild Codex argv[0] helper links for both the old and current native binary layouts

## Why

Recent Codex CLI releases changed the generated app-server schema and native package layout. The previous initialize request is missing `requestAttestation`, while several older request fields are no longer accepted.

The frontend also previously assumed a domain-root deployment. Building a fixed subpath into the assets solves only one proxy layout and requires a separate image for every prefix. This change keeps asset URLs relative and injects a sanitized base path into each HTML response, so one image works at `/` and at prefixes such as `/codex/`.

The previous runtime image built the complete mise/Node/Python/Codex tree inside `/root` and then archived the same tree into `/opt/root-seed.tar.gz`, retaining both copies in immutable layers. The updated multi-stage layout produces the seed outside the final image and copies it once. Compiler packages and all tools provided by the original image remain available.

## Reverse proxy behavior

A root proxy needs no additional header. A subpath proxy should strip its public prefix before forwarding and set, for example:

```nginx
proxy_set_header X-Forwarded-Prefix /codex;
```

The backend normalizes the header and renders the matching HTML `<base href>`. Invalid values fall back safely to `/`.

## Validation

- frontend lint passed
- frontend and backend builds passed
- backend tests passed: 19 suites / 142 tests
- full Docker image build passed with Codex CLI 0.149.1
- verified Codex, Node, Python, uv, pnpm, MCP utilities, compiler toolchain, native PTY/SQLite modules, and argv[0] helper links
- root-proxy smoke test passed: assets, deep SPA routes, login/status APIs, and WebSocket transport
- `/codex/` proxy smoke test passed with the same image: assets, deep SPA routes, login/status APIs, and WebSocket transport
- container initialization and restart persistence passed with bind-mounted `/root` and `/workspaces`
