### PR TITLE
fix(docker): 修复全新 root 的工具链初始化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ rebuild_codex_arg0_symlinks() {
   local codex_bin
   codex_bin="$(find /root/.local/share/mise -type f -name codex \
     \( -path '*/vendor/*/bin/codex' -o -path '*/vendor/*/codex/codex' \) \
-    2>/dev/null | head -1)"
+    2>/dev/null | head -1 || true)"
   if [ -n "${codex_bin}" ]; then
     for tool in apply_patch applypatch codex-execve-wrapper codex-linux-sandbox; do
       ln -sf "${codex_bin}" "/usr/local/bin/${tool}"
@@ -160,14 +160,19 @@ rebuild_codex_arg0_symlinks() {
   fi
 }
 
-is_root_empty() {
-  find /root -mindepth 1 -maxdepth 1 -print -quit | grep -q . && return 1
-  return 0
+is_root_seedable() {
+  # Debian already ships standard shell startup files in /root. A root that
+  # contains only those files is still fresh and should receive the seed.
+  ! find /root -mindepth 1 -maxdepth 1 \
+    ! -name '.profile' \
+    ! -name '.bashrc' \
+    ! -name '.bash_logout' \
+    -print -quit | grep -q .
 }
 
 # ── Phase 1: Root seed restore ──────────────────────────────────────
-if is_root_empty; then
-  echo "[entrypoint] /root is empty, restoring seed data..."
+if is_root_seedable; then
+  echo "[entrypoint] /root is fresh, restoring seed data..."
   tar -C /root -xzf "${ROOT_SEED}"
   touch "${ROOT_MARKER}"
   echo "${CODEX_CLI_VERSION:-unknown}" > "${VERSION_MARKER}"


### PR DESCRIPTION
## 改动说明 / What changed

修复 Docker 镜像首次启动时对 `/root` 的错误判定：

- Debian 基础镜像自带 `.profile`、`.bashrc`，原逻辑因此不会解包工具链 seed
- 将仅包含标准 shell 启动文件的 `/root` 视为可初始化
- 真实用户文件存在时仍保持原保护行为，不覆盖数据
- 避免缺少 mise 目录时，`find | head` 在 `set -euo pipefail` 下导致入口脚本意外退出

不引入新依赖，不修改现有挂载结构。

## 关联 issue / Related issues

Closes #9

## 改动类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 重构，不改变外部行为 / Refactor with no behaviour change
- [ ] 文档 / Documentation
- [x] 构建、CI、部署 / Build, CI or deployment

## 验证 / Verification

- [ ] `pnpm lint` 通过 / passes（仅修改 Docker 入口脚本，未重复运行）
- [ ] `pnpm test` 通过 / passes（仅修改 Docker 入口脚本，未重复运行）
- [ ] `cd web && pnpm test` 通过 / passes（仅修改 Docker 入口脚本，未重复运行）
- [ ] 手动验证过受影响的界面 / Manually verified the affected UI（无 UI 改动）

实际构建上游默认 CLI 0.151.0 镜像并验证：

1. 不挂载 `/root`：自动恢复 seed，`codex --version` 成功。
2. 挂载空宿主目录到 `/root`：自动恢复 seed。
3. 挂载包含 `user-data` 文件的目录：不覆盖文件、不写初始化标记，入口脚本不再因 pipefail 提前退出。
4. `git diff --check` 通过。

## 检查项 / Checklist

- [x] 改动范围收敛在本 PR 的目标内，没有夹带无关修改 / Scope is limited to this PR's goal, no unrelated changes
- [x] 未修改数据库 schema / Database schema unchanged
- [x] 未修改后端接口 / Backend endpoints unchanged
- [x] 未新增 UI 文案 / No new UI strings
- [x] 文档无需更新：行为与现有首次初始化设计一致 / No docs update needed; this restores the documented initialization behavior

## 补充信息 / Additional notes

修复分支来自我的 fork：https://github.com/kot4ri/codex-webui/tree/fix/docker-root-initialization