### PR TITLE
fix(web): 重连或后台恢复后补拉会话，避免时间线停留在旧快照

### DIFF
--- a/web/src/hooks/use-codex-socket.ts
+++ b/web/src/hooks/use-codex-socket.ts
@@ -34,14 +34,51 @@ export function useCodexSocket(enabled = true) {
 
     const socket = getSocket();
 
+    /**
+     * Re-reads the open thread after a delivery gap.
+     *
+     * Socket.IO only delivers events emitted while connected; a suspended tab
+     * or a dropped socket therefore misses every notification in between and
+     * the transcript stays frozen at its last snapshot. Resubscribing restores
+     * future events but never back-fills the gap, so the open thread has to be
+     * re-read from the server. `recordActive: false` keeps the active-branch
+     * pointer naming what the user last chose.
+     */
+    let resyncing = false;
+    const resyncSelectedThread = () => {
+      const store = useTimelineStore.getState();
+      const threadId = store.threadId;
+      if (!threadId || resyncing) return;
+      if (!store.getThreadRuntime(threadId)?.hydrated) return;
+
+      resyncing = true;
+      void threadsResumeThread({
+        path: { threadId },
+        query: { recordActive: false },
+      })
+        .then(({ data }) => {
+          if (data) applyOpenResponse(data);
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          resyncing = false;
+        });
+    };
+
     const handleConnect = () => {
       setConnected(true);
       useTimelineStore.getState().resubscribeAll();
+      resyncSelectedThread();
     };
     const handleDisconnect = () => setConnected(false);
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') resyncSelectedThread();
+    };
+
     socket.on('connect', handleConnect);
     socket.on('disconnect', handleDisconnect);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     const ctx: NotificationContext = {
       threadId: null,
@@ -262,6 +299,7 @@ export function useCodexSocket(enabled = true) {
     return () => {
       socket.off('connect', handleConnect);
       socket.off('disconnect', handleDisconnect);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       socket.off('codex.notification', handleCodexNotification);
       socket.off('codex.lifecycle', handleCodexLifecycle);
       socket.off('codex.serverRequest', handleCodexServerRequest);


### PR DESCRIPTION
## 改动说明 / What changed

修复多端同时打开同一会话时的“PC 端近期内容丢失”问题：PC 端长期驻留 / 标签页被挂起后，时间线停留在旧快照（例如只看得到昨天的消息），而手机端重新打开会话能看到最新内容。

**根因**

- Socket.IO 只投递连接期间产生的事件；标签页被挂起或 socket 断开期间错过的 `item/*`、`turn/*` 通知不会重放。
- 前端重连时只执行 `resubscribeAll()`，恢复的是**后续**事件，不会回补断线期间缺失的历史，所以时间线停留在最后收到的快照。
- 手机端每次打开会话都会走 `thread/resume` 并拿到最近的 `initialTurnsPage`，因此显示正常。
- 已确认服务端数据完整：`thread/turns/list` 能查到最近的 turns，不是数据丢失。

**修复**

- `web/src/hooks/use-codex-socket.ts`：
  - 在 `connect`（含重连）时，除了重新订阅，还对当前已 hydrate 的打开会话执行 `threadsResumeThread({ recordActive: false })`，并复用 `applyOpenResponse` 同步最近一页 turns；
  - 在 `visibilitychange` 变为可见时做同样的补偿，覆盖移动端 / 桌面端标签页被挂起但不断开 socket 的场景；
  - 用 in-flight 标志避免并发重入；`recordActive: false` 保持分支 active 指针仍指向用户最后选择的版本。

## 关联 issue / Related issues

用户报告：手机和 PC 同时打开同一会话时，PC 端只显示历史内容，移动端正常显示最近聊天。

## 改动类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 重构，不改变外部行为 / Refactor with no behaviour change
- [ ] 文档 / Documentation
- [ ] 构建、CI、部署 / Build, CI or deployment

## 验证 / Verification

- [x] `cd web && pnpm lint` 通过
- [x] `cd web && pnpm test` 通过：22 个文件 / 218 个用例全部通过（需 `env -u NODE_ENV`，容器内 `NODE_ENV=production` 会让 React 生产构建缺少 `act`）
- [x] `cd web && pnpm build` 通过
- [x] Playwright 实测（临时 Vite dev + 现有后端）：
  - `context.setOffline(true) → setOffline(false)` 触发 socket 重连后，前端补发 `POST /api/threads/:id/resume?recordActive=false`
  - 手动派发 `visibilitychange`（页面可见）同样触发一次带 `recordActive=false` 的 resume
  - 补偿前后时间线内容保持完整（虚拟列表 item 数一致），没有把会话清空

## 检查项 / Checklist

- [x] 改动范围收敛在本 PR 的目标内，没有夹带无关修改
- [ ] 改了数据库 schema 的话，已跑 `pnpm db:generate` 并提交了 `drizzle/` 下的迁移（本 PR 未改 schema）
- [ ] 改了后端接口的话，已重新生成前端 SDK（本 PR 未改后端接口）
- [x] 新增 UI 文案已走 i18n（本 PR 未新增 UI 文案）
- [ ] 已同步更新受影响的 `docs/` 文档（无必要）

## 补充信息 / Additional notes

- 该补偿会复用 `applyOpenResponse` 的既有语义：当服务端最近一页包含本地未见过的 turn 时，以服务端视图为准整体替换时间线，这是为断线/换设备后做一致性收敛的有意取舍。
- 验证过程中观察到控制台仍有 `flushSync was called from inside a lifecycle method` 报错，与本次改动无关，可作为后续单独排查项。